### PR TITLE
feat: clean up the view graph

### DIFF
--- a/apps/www/src/state/plugin/viewForm/toggleButtons.js
+++ b/apps/www/src/state/plugin/viewForm/toggleButtons.js
@@ -12,7 +12,7 @@ export default function (store) {
 
   return async () => {
     const { pointer } = store.getState().viewForm
-    const view = prepareViewPointer(pointer)
+    const view = prepareViewPointer(pointer, { cleanup: false })
 
     dispatch.setViewValidity(await validate(view, ViewValidationShapes))
     dispatch.setSourcesValidity(await validate(view, GenerateDimensionsShapes))

--- a/packages/view-util/index.js
+++ b/packages/view-util/index.js
@@ -8,7 +8,6 @@ import { removeApiProperties, sourcesToBlankNodes } from './lib/viewGraph.js'
 export function prepareViewPointer(pointer, { cleanup = true } = {}) {
   let dataset = $rdf.dataset([...pointer.dataset])
   if (cleanup) {
-    dataset = dataset.filter(removeApiProperties)
     dataset = sourcesToBlankNodes(dataset)
   }
 
@@ -29,7 +28,9 @@ export function prepareViewPointer(pointer, { cleanup = true } = {}) {
 
   view.addOut(ns.view.dimension, view.out(ns.view.filter).out(ns.view.dimension))
 
-  return view
+  return clownface({
+    dataset: dataset.filter(removeApiProperties),
+  }).node(pointer)
 }
 
 export function createViewQuery(pointer) {

--- a/packages/view-util/index.js
+++ b/packages/view-util/index.js
@@ -1,11 +1,16 @@
 import clownface from 'clownface'
-import $rdf from '@rdfjs/dataset'
+import $rdf from 'rdf-ext'
 import View from 'rdf-cube-view-query/lib/View.js'
 import * as ns from '@view-builder/core/ns.js'
 import { createFilterDimension, generateLookupSources } from './lib/filters.js'
+import { removeApiProperties, sourcesToBlankNodes } from './lib/viewGraph.js'
 
-export function prepareViewPointer(pointer) {
-  const dataset = $rdf.dataset([...pointer.dataset])
+export function prepareViewPointer(pointer, { cleanup = true } = {}) {
+  let dataset = $rdf.dataset([...pointer.dataset])
+  if (cleanup) {
+    dataset = dataset.filter(removeApiProperties)
+    dataset = sourcesToBlankNodes(dataset)
+  }
 
   const view = clownface({ dataset }).node(pointer)
 

--- a/packages/view-util/lib/viewGraph.js
+++ b/packages/view-util/lib/viewGraph.js
@@ -1,5 +1,5 @@
 import * as ns from '@view-builder/core/ns.js'
-import { hydra, rdf } from '@tpluscode/rdf-ns-builders'
+import { hydra } from '@tpluscode/rdf-ns-builders'
 import $rdf from 'rdf-ext'
 import TermMap from '@rdfjs/term-map'
 
@@ -14,11 +14,15 @@ export function removeApiProperties({ predicate }) {
 
 export function sourcesToBlankNodes(dataset) {
   function isSource(term) {
-    return dataset.match(term, rdf.type, ns.view.CubeSource).size > 0
+    return dataset.match(null, ns.view.source, term).size > 0
   }
 
   const map = new TermMap()
   function toBlank(term) {
+    if (term.termType === 'BlankNode') {
+      return term
+    }
+
     if (!map.has(term)) {
       map.set(term, $rdf.blankNode())
     }

--- a/packages/view-util/lib/viewGraph.js
+++ b/packages/view-util/lib/viewGraph.js
@@ -1,0 +1,40 @@
+import * as ns from '@view-builder/core/ns.js'
+import { hydra, rdf } from '@tpluscode/rdf-ns-builders'
+import $rdf from 'rdf-ext'
+import TermMap from '@rdfjs/term-map'
+
+const viewBuilderNs = ns.viewBuilder().value
+const hydraNs = hydra().value
+
+export function removeApiProperties({ predicate }) {
+  const url = predicate.value
+
+  return !url.startsWith(viewBuilderNs) && !url.startsWith(hydraNs)
+}
+
+export function sourcesToBlankNodes(dataset) {
+  function isSource(term) {
+    return dataset.match(term, rdf.type, ns.view.CubeSource).size > 0
+  }
+
+  const map = new TermMap()
+  function toBlank(term) {
+    if (!map.has(term)) {
+      map.set(term, $rdf.blankNode())
+    }
+
+    return map.get(term)
+  }
+
+  return dataset.map((quad) => {
+    let { subject, predicate, object, graph } = quad
+    if (isSource(subject)) {
+      subject = toBlank(subject)
+    }
+    if (isSource(object)) {
+      object = toBlank(object)
+    }
+
+    return $rdf.quad(subject, predicate, object, graph)
+  })
+}

--- a/packages/view-util/package.json
+++ b/packages/view-util/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@view-builder/testing": "0.0.0",
-    "chai": "^4.3.6"
+    "chai": "^4.3.6",
+    "is-graph-pointer": "^1.2.2"
   }
 }

--- a/packages/view-util/package.json
+++ b/packages/view-util/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "dependencies": {
     "@rdfjs/term-map": "^2",
-    "@rdfjs/traverser": "^0.1.0",
     "@tpluscode/rdf-ns-builders": "^2.0.1",
     "@view-builder/core": "0.0.0",
     "clownface": "^1.5.1",

--- a/packages/view-util/package.json
+++ b/packages/view-util/package.json
@@ -4,11 +4,13 @@
   "type": "module",
   "main": "index.js",
   "dependencies": {
-    "@rdfjs/dataset": "^2.0.0",
+    "@rdfjs/term-map": "^2",
+    "@rdfjs/traverser": "^0.1.0",
     "@tpluscode/rdf-ns-builders": "^2.0.1",
     "@view-builder/core": "0.0.0",
     "clownface": "^1.5.1",
-    "rdf-cube-view-query": "^1.10.0"
+    "rdf-cube-view-query": "^1.10.0",
+    "rdf-ext": "^2.0.0"
   },
   "devDependencies": {
     "@view-builder/testing": "0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2105,6 +2105,16 @@
   dependencies:
     readable-stream "^3.6.0"
 
+"@rdfjs/score@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@rdfjs/score/-/score-0.1.1.tgz#8431cbf62458eb28ddc06dcbd02ee5d814d4f492"
+  integrity sha512-+t9Sf5nFUJTvH8X2Xy7H+egLKIyVCwlDzCGrWThSrSCmIENcC9n3+GkMMImnsmYDeSXaWi3awcI1f1TmA84FIQ==
+  dependencies:
+    "@rdfjs/data-model" "^2.0.1"
+    "@rdfjs/term-map" "^2.0.0"
+    "@rdfjs/term-set" "^2.0.1"
+    "@rdfjs/to-ntriples" "^2.0.0"
+
 "@rdfjs/serializer-jsonld-ext@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@rdfjs/serializer-jsonld-ext/-/serializer-jsonld-ext-3.0.0.tgz#96e05494638ec9affdafd63dd8e4da90e7fa01e6"
@@ -2161,7 +2171,7 @@
   dependencies:
     "@rdfjs/to-ntriples" "^2.0.0"
 
-"@rdfjs/term-map@^2.0.0":
+"@rdfjs/term-map@^2", "@rdfjs/term-map@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@rdfjs/term-map/-/term-map-2.0.0.tgz#6360314e9b62a1d540b213865403130721be1123"
   integrity sha512-z0K8AgLsJGTrh+dGkXNl/oT9vBdMei4xq1MIeGN360oimA81Q+ruQUKFCbYNRRZS03tVHPBzqXUal/DezFGPEA==
@@ -2175,7 +2185,7 @@
   dependencies:
     "@rdfjs/to-ntriples" "^2.0.0"
 
-"@rdfjs/term-set@^2.0.0":
+"@rdfjs/term-set@^2.0.0", "@rdfjs/term-set@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@rdfjs/term-set/-/term-set-2.0.1.tgz#bbf406e0477c226e65753da2da0089cbbe847ab5"
   integrity sha512-ZD8IwSY7tPpevs2iaQEsesAu8c7TO4GKHQHObbehUE4odKa9BuhuimdNuYwBoyVprTtHARaW6VW+0Jsu7ehD+Q==
@@ -9311,10 +9321,10 @@ rdf-ext@^1.3.0, rdf-ext@^1.3.1, rdf-ext@^1.3.5:
     rdf-normalize "^1.0.0"
     readable-stream "^3.6.0"
 
-rdf-ext@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/rdf-ext/-/rdf-ext-2.0.1.tgz#b0bffd05a7d905e51dcf98ef4df1f83c6085f3cf"
-  integrity sha512-+vFw89UBKg24EnUxivto7FeWUIWluA968EU9+71pHtD/UUdIjAVoTShYZAu/cmh9gJ9u3dpqRXsn8fKeC4SVLQ==
+rdf-ext@^2.0.0, rdf-ext@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/rdf-ext/-/rdf-ext-2.1.0.tgz#313e67983adaac74af8ee16e6446ff82eff33b47"
+  integrity sha512-gUm6wynD9o2odOvpr+hY0Gr8iH8NNpQytu6Hqp8oY5rkYImWjs9TGh8ioy/BXaxkzcKNmU8j6ovlFSSvxCMOwA==
   dependencies:
     "@rdfjs/data-model" "^2.0.0"
     "@rdfjs/dataset" "^2.0.0"
@@ -9323,6 +9333,7 @@ rdf-ext@^2.0.1:
     "@rdfjs/namespace" "^2.0.0"
     "@rdfjs/normalize" "^2.0.0"
     "@rdfjs/prefix-map" "^0.1.0"
+    "@rdfjs/score" "^0.1.1"
     "@rdfjs/term-map" "^2.0.0"
     "@rdfjs/term-set" "^2.0.0"
     "@rdfjs/to-ntriples" "^2.0.0"


### PR DESCRIPTION
Two things to clean up the view graph when sending it to viewer etc:

1. Source URIs are replaced with blank nodes
2. Properties from view builder's own namespace and `hydra:` are removed