### PR TITLE
feat: display date of last publish

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
     "onetime": "^6.0.0",
     "rdf-dataset-ext": "^1.0.1",
     "rdf-ext": "^2.0.1",
+    "rdf-literal": "^1.3.0",
     "sparql-http-client": "^2.4.1"
   },
   "devDependencies": {

--- a/apps/api/resources/api/ViewCollection.ttl
+++ b/apps/api/resources/api/ViewCollection.ttl
@@ -28,6 +28,10 @@ prefix view-builder: <https://view-builder.described.at/>
           code:link <file:apps/api/lib/viewCollection.js#construct> ;
         ] ;
     ] ;
+  query:include
+  [
+    query:path view-builder:publish ;
+  ];
   hydra:supportedOperation
     [
       a schema:CreateAction ;

--- a/apps/api/resources/api/event-handler/on-views-published.ttl
+++ b/apps/api/resources/api/event-handler/on-views-published.ttl
@@ -1,0 +1,24 @@
+PREFIX view-builder: <https://view-builder.described.at/>
+PREFIX code: <https://code.described.at/>
+PREFIX as: <https://www.w3.org/ns/activitystreams#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix events: <https://hypermedia.app/events#>
+
+<>
+  a events:EventHandler ;
+  events:eventSpec
+    [
+      rdf:predicate rdf:type ;
+      rdf:object view-builder:ViewsPublished ;
+    ] ;
+  events:objectSpec
+    [
+      rdf:predicate rdf:type ;
+      rdf:object </api/ViewsPublishing> ;
+    ] ;
+  code:implementedBy
+    [
+      a code:EcmaScriptModule ;
+      code:link <file:apps/api/lib/viewCollection/publish.js#setPublishedDate> ;
+    ] ;
+.

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -43,6 +43,7 @@
     "n3": "^1.16.2",
     "nanoid": "^4.0.0",
     "rdf-ext": "^2.0.1",
+    "rdf-literal": "^1.3.0",
     "rdf-validate-shacl": "^0.4.4",
     "sparql-http-client": "^2.4.1",
     "string-to-stream": "^3.0.1",

--- a/apps/www/src/view/viewCollection.js
+++ b/apps/www/src/view/viewCollection.js
@@ -2,6 +2,8 @@ import { html } from 'lit'
 import { hydra, schema } from '@tpluscode/rdf-ns-builders'
 import '@shoelace-style/shoelace/dist/components/button/button.js'
 import '../element/ssz-view-table.js'
+import { viewBuilder } from '@view-builder/core/ns.js'
+import { fromRdf } from 'rdf-literal'
 import { searchForm } from './searchForm.js'
 
 export async function init() {
@@ -29,6 +31,7 @@ function menu({ dispatch }) {
   return html`
     <sl-menu-label>Views</sl-menu-label>
     <sl-menu-item @click=${() => dispatch.app.viewParam('#create')}>Create new view</sl-menu-item>
+    <sl-menu-label>Publishing</sl-menu-label>
     <sl-menu-item @click=${() => dispatch.app.viewParam('#publish')}>Publish views</sl-menu-item>
   `
 }
@@ -64,6 +67,11 @@ function publishForm({ state, dispatch }) {
     return html`<sl-spinner></sl-spinner>`
   }
 
+  const datePublished = state.viewCollection.pointer
+    .out(viewBuilder.publish)
+    .out(schema.datePublished)
+    .term
+
   function submit(e) {
     dispatch.operation.invoke({
       operation,
@@ -77,6 +85,8 @@ function publishForm({ state, dispatch }) {
         ${operation.title}
       </sl-button>
     </shaperone-form>
+    <br>
+    Last published: ${datePublished ? fromRdf(datePublished).toLocaleString() : 'never'}
     `
 }
 


### PR DESCRIPTION
I noticed that I previously missed a requirement for the timestamp of last publishing to be persisted and displayed

This adds that to the publishing (not download) and displays below the publishing form

<img width="573" alt="image" src="https://user-images.githubusercontent.com/588128/199003161-4620f2e1-4fb3-4505-8ddc-c8c0d1d7ed96.png">
