### PR TITLE
fix: load published views with construct

### DIFF
--- a/apps/api/resources.dev/view/example.ttl
+++ b/apps/api/resources.dev/view/example.ttl
@@ -11,6 +11,15 @@ prefix view: <https://cube.link/view/>
   view-builder:source <#source-bew>, <#source-stf> ;
   schema:author </user/tpluscode> ;
   view-builder:publish true ;
+  view:dimension
+    [
+      rdfs:label "ZEIT" ;
+      view:from
+        [
+          view:source <#source-bew>, <#source-stf> ;
+          view:path <https://ld.stadt-zuerich.ch/statistics/property/ZEIT> ;
+        ] ;
+    ] ;
 .
 
 <#source-bew>

--- a/packages/publish-views/lib/loadViews.js
+++ b/packages/publish-views/lib/loadViews.js
@@ -1,4 +1,4 @@
-import { DESCRIBE, SELECT } from '@tpluscode/sparql-builder'
+import { CONSTRUCT, SELECT } from '@tpluscode/sparql-builder'
 import * as ns from '@view-builder/core/ns.js'
 import through2 from 'through2'
 import $rdf from 'rdf-ext'
@@ -15,7 +15,10 @@ export default async function loadViewsToPublish() {
     .execute(client.query)
 
   return views.pipe(through2.obj(async function ({ view }, _, next) {
-    const viewQuads = await DESCRIBE`${view}`.execute(client.query)
+    const viewQuads = await CONSTRUCT`?s ?p ?o`
+      .FROM(view)
+      .WHERE`?s ?p ?o`
+      .execute(client.query)
 
     const dataset = await $rdf.dataset().import(viewQuads)
     this.push(clownface({ dataset, term: view }))

--- a/packages/publish-views/package.json
+++ b/packages/publish-views/package.json
@@ -9,7 +9,7 @@
     "prestart:store": "mkdir .pipeline; cat pipeline/main.ttl pipeline/to-ntriples.ttl pipeline/to-store.ttl > .pipeline/to-store.ttl",
     "start:store": "dotenv -e ../../.env.local -- barnard59 run --pipeline ToStore --variable-all .pipeline/to-store.ttl",
     "pretest": "yarn start:file",
-    "test": "shacl-cli validate --shapes test/shape*.ttl --data output/views.nt"
+    "test": "shacl-cli validate --shapes test/shape*.ttl --shapes ../../packages/core/shape/ViewValidationShape.ttl --data output/views.nt"
   },
   "dependencies": {
     "@tpluscode/rdf-ns-builders": "^2",


### PR DESCRIPTION
I forgot that the views in the builder user URIs for source identifiers.

Thus `DESCRIBE` was not enough and caused view to be published without sources 🙈 

The next simplest thing is to load all triples from the view's graph