### PR TITLE
refactor: validate dimensions/etc in the pipeline

### DIFF
--- a/apps/api/lib/viewCollection/publish.js
+++ b/apps/api/lib/viewCollection/publish.js
@@ -5,9 +5,6 @@ import { DELETE } from '@tpluscode/sparql-builder'
 import { schema } from '@tpluscode/rdf-ns-builders'
 import { toRdf } from 'rdf-literal'
 import { temporaryFileTask } from 'tempy'
-import { createRequire } from 'module'
-
-const require = createRequire(import.meta.url)
 
 export default asyncMiddleware(async (req, res, next) => {
   const payload = await req.resource()
@@ -26,7 +23,6 @@ function downloadViews(req, res, next, ignoreWarnings) {
       temporaryPath,
       {
         METADATA_ENDPOINT: process.env.METADATA_ENDPOINT,
-        'view-shapes': require.resolve('@view-builder/publish-views/shapes.ttl'),
         ignoreWarnings,
       },
     )
@@ -59,7 +55,6 @@ async function publish(req, res, next, ignoreWarnings) {
     PUBLIC_VIEWS_GRAPH,
     METADATA_ENDPOINT,
     ignoreWarnings,
-    'view-shapes': require.resolve('@view-builder/publish-views/shapes.ttl'),
   })
 
   run.finished

--- a/apps/api/resources.dev/view/example.ttl
+++ b/apps/api/resources.dev/view/example.ttl
@@ -11,6 +11,15 @@ prefix view: <https://cube.link/view/>
   view-builder:source <#source-bew>, <#source-stf> ;
   schema:author </user/tpluscode> ;
   view-builder:publish true ;
+  view:dimension
+    [
+      rdfs:label "ZEIT" ;
+      view:from
+        [
+          view:source <#source-bew>, <#source-stf> ;
+          view:path <https://ld.stadt-zuerich.ch/statistics/property/ZEIT> ;
+        ] ;
+    ] ;
 .
 
 <#source-bew>

--- a/apps/api/resources.dev/view/example2.ttl
+++ b/apps/api/resources.dev/view/example2.ttl
@@ -16,6 +16,15 @@ prefix view: <https://cube.link/view/>
       view:limit 100 ;
       view:offset 1000 ;
     ] ;
+  view:dimension
+    [
+      rdfs:label "ZEIT" ;
+      view:from
+        [
+          view:source <#source-bew>, <#source-stf> ;
+          view:path <https://ld.stadt-zuerich.ch/statistics/property/ZEIT> ;
+        ] ;
+    ] ;
 .
 
 <#source-bew>

--- a/packages/publish-views/lib/ValidationError.js
+++ b/packages/publish-views/lib/ValidationError.js
@@ -11,7 +11,15 @@ export class ValidationError extends Error {
 
     super(`${reports.length} views failed. ${total} issues found`)
 
-    this.reports = combineReports(reports)
+    Object.defineProperty(this, 'dataset', {
+      enumerable: false,
+      value: combineReports(reports),
+    })
+    Object.defineProperty(this, 'reports', {
+      enumerable: false,
+      value: clownface({ dataset: this.dataset })
+        .has(rdf.type, sh.ValidationReport),
+    })
   }
 }
 
@@ -22,8 +30,7 @@ function combineReports(reports) {
     dataset.addAll([...pointer.dataset].map(prefixBlankNodes(`r${index}`)))
   })
 
-  return clownface({ dataset })
-    .has(rdf.type, sh.ValidationReport)
+  return dataset
 }
 
 function prefixBlankNodes(prefix) {

--- a/packages/publish-views/lib/shacl.js
+++ b/packages/publish-views/lib/shacl.js
@@ -16,7 +16,7 @@ export function combineShaclReports({ context, report }) {
 }
 
 export function failOnAnyViolations() {
-  const { variables } = this
+  const { variables, logger } = this
   const ignoreWarnings = variables.get('ignoreWarnings')
 
   return through2.obj(function (chunk, _, next) {
@@ -25,7 +25,9 @@ export function failOnAnyViolations() {
   }, function (done) {
     const reports = variables.get(REPORTS_KEY)
     if (reports?.some(hasViolations(ignoreWarnings))) {
-      this.destroy(new ValidationError(reports))
+      const error = new ValidationError(reports)
+      logger.error(error.dataset.toString())
+      this.destroy(error)
     }
 
     done()

--- a/packages/publish-views/lib/shapes.js
+++ b/packages/publish-views/lib/shapes.js
@@ -5,9 +5,12 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 import clownface from 'clownface'
 import { schema, sh } from '@tpluscode/rdf-ns-builders'
+import { createRequire } from 'module'
+import concat from 'barnard59-base/concat.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const shapePath = path.join(__dirname, '../shapes.ttl')
+const require = createRequire(import.meta.url)
 
 export const viewShape = onetime(async () => {
   const dataset = await $rdf.dataset().import(fromFile(shapePath))
@@ -15,3 +18,10 @@ export const viewShape = onetime(async () => {
   return clownface({ dataset })
     .has(sh.targetClass, schema.Dataset)
 })
+
+export function validationShapes() {
+  const metadataShapes = fromFile(require.resolve('../shapes.ttl'))
+  const viewShapes = fromFile(require.resolve('@view-builder/core/shape/ViewValidationShape.ttl'))
+
+  return concat.object(metadataShapes, viewShapes)
+}

--- a/packages/publish-views/lib/shapes.js
+++ b/packages/publish-views/lib/shapes.js
@@ -1,27 +1,25 @@
 import onetime from 'onetime'
 import { fromFile } from 'rdf-utils-fs'
 import $rdf from 'rdf-ext'
-import path from 'path'
-import { fileURLToPath } from 'url'
 import clownface from 'clownface'
 import { schema, sh } from '@tpluscode/rdf-ns-builders'
 import { createRequire } from 'module'
 import concat from 'barnard59-base/concat.js'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const shapePath = path.join(__dirname, '../shapes.ttl')
 const require = createRequire(import.meta.url)
+const metadataShapesPath = require.resolve('../shapes.ttl')
+const viewShapesPath = require.resolve('@view-builder/core/shape/ViewValidationShape.ttl')
 
 export const viewShape = onetime(async () => {
-  const dataset = await $rdf.dataset().import(fromFile(shapePath))
+  const dataset = await $rdf.dataset().import(fromFile(metadataShapesPath))
 
   return clownface({ dataset })
     .has(sh.targetClass, schema.Dataset)
 })
 
 export function validationShapes() {
-  const metadataShapes = fromFile(require.resolve('../shapes.ttl'))
-  const viewShapes = fromFile(require.resolve('@view-builder/core/shape/ViewValidationShape.ttl'))
+  const metadataShapes = fromFile(metadataShapesPath)
+  const viewShapes = fromFile(viewShapesPath)
 
   return concat.object(metadataShapes, viewShapes)
 }

--- a/packages/publish-views/pipeline/main.ttl
+++ b/packages/publish-views/pipeline/main.ttl
@@ -19,15 +19,6 @@
           <#loadViews> <#prepareView> <#pointerToDataset> <#validate> <#checkShaclReports> <#flatten>
         )
     ] ;
-  :variables
-    [
-      :variable
-        [
-          a :Variable ;
-          :name "view-shapes" ;
-          :value "shapes.ttl" ;
-        ] ;
-    ] ;
 .
 
 <#loadViews>
@@ -102,15 +93,7 @@
             code:implementedBy
               [
                 a code:EcmaScriptModule ;
-                code:link <node:fs#createReadStream> ;
-              ] ;
-            code:arguments ("view-shapes"^^:VariableName) ;
-          ]
-          [
-            code:implementedBy
-              [
-                a code:EcmaScriptModule ;
-                code:link <node:barnard59-formats/n3.js#parse> ;
+                code:link <file:../lib/shapes.js#validationShapes> ;
               ] ;
           ]
         )


### PR DESCRIPTION
This is partially overlapping #43 

I simplify how the API calls the pipeline by integrating how the shapes are loaded into the steps and also include the shape to validate against the `cube.link/view` spec