### PR TITLE
refactor: use alternateName and not identifier from meta objects

### DIFF
--- a/apps/api/lib/sourceViewCollection.js
+++ b/apps/api/lib/sourceViewCollection.js
@@ -1,9 +1,10 @@
 import $rdf from 'rdf-ext'
 import clownface from 'clownface'
 import asyncMiddleware from 'middleware-async'
-import { hydra, rdf, rdfs, schema } from '@tpluscode/rdf-ns-builders'
+import { dcterms, hydra, rdf, rdfs, schema } from '@tpluscode/rdf-ns-builders'
 import { CONSTRUCT } from '@tpluscode/sparql-builder'
 import { cube } from '@zazuko/vocabulary-extras/builders'
+import { viewBuilder } from '@view-builder/core/ns.js'
 
 /**
  * GET handler for loading view metadata from the metadata endpoint
@@ -11,6 +12,8 @@ import { cube } from '@zazuko/vocabulary-extras/builders'
  * The response is a hydra collection
  */
 export const get = asyncMiddleware(async (req, res) => {
+  const publisher = req.knossos.config.out(viewBuilder.publisher).term
+
   const collection = clownface({
     dataset: $rdf.dataset(),
     term: req.hydra.term,
@@ -25,13 +28,14 @@ export const get = asyncMiddleware(async (req, res) => {
       ?view a ${schema.Dataset} ;
             ${schema.name} ?label ;
             ${schema.alternateName} ?uniqueId ;
+            ${dcterms.publisher} ${publisher} ;
       .
     }
     
     FILTER NOT EXISTS {
       [
         # Exclude views which already exist in view builder
-        a ${cube('view/View')} ; ${schema.sameAs} ?view
+        a ${cube('view/View')} ; ${schema.alternateName} ?uniqueId
       ]
     }
   `.execute(req.labyrinth.sparql.query)

--- a/apps/api/lib/viewCollection.js
+++ b/apps/api/lib/viewCollection.js
@@ -39,7 +39,6 @@ export function construct({ client }) {
     // TODO: Construct generated from NodeShape
     return CONSTRUCT`
       ?resource a ?type ;
-                ${schema.identifier} ?id ; 
                 ${schema.name} ?name ; 
                 ${schema.alternateName} ?alt .
                 
@@ -49,7 +48,6 @@ export function construct({ client }) {
       ${VALUES(...resources)}
 
       ?resource a ?type ;
-                ${schema.identifier} ?id ; 
                 ${schema.name} ?name ; 
                 ${schema.alternateName} ?alt .
                 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,8 +9,10 @@
   "dependencies": {
     "@hydrofoil/knossos": "^0.9.11",
     "@hydrofoil/vocabularies": "^0.3.3",
+    "@rdfine/hydra": "^0.8.6",
     "@rdfine/shacl": "^0.8.7",
     "@tpluscode/rdf-ns-builders": "^2.0.1",
+    "@tpluscode/rdfine": "^0.5.41",
     "@tpluscode/sparql-builder": "^0.3.23",
     "@view-builder/core": "^0.0.0",
     "@view-builder/publish-views": "^0.0.0",

--- a/apps/api/resources.dev/view/example.ttl
+++ b/apps/api/resources.dev/view/example.ttl
@@ -4,8 +4,8 @@ prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix view: <https://cube.link/view/>
 
 <> a </api/View>, view:View ;
-  schema:sameAs <https://ld.stadt-zuerich.ch/statistics/view/677> ;
-  schema:identifier "677" ;
+  schema:isBasedOn <https://ld.stadt-zuerich.ch/statistics/meta/object/677> ;
+  schema:sameAs <https://ld.stadt-zuerich.ch/statistics/view/BEV344OD3440> ;
   schema:alternateName "BEV344OD3440" ;
   schema:name "Bevölkerungsszenarien 2022 – 2040" ;
   view-builder:source <#source-bew>, <#source-stf> ;

--- a/apps/api/resources.dev/view/example1.ttl
+++ b/apps/api/resources.dev/view/example1.ttl
@@ -4,8 +4,8 @@ prefix view: <https://cube.link/view/>
 prefix view-builder: <https://view-builder.described.at/>
 
 <> a </api/View>, view:View ;
-  schema:sameAs <https://ld.stadt-zuerich.ch/statistics/view/678> ;
-  schema:identifier "678" ;
+  schema:isBasedOn <https://ld.stadt-zuerich.ch/statistics/meta/object/678> ;
+  schema:sameAs <https://ld.stadt-zuerich.ch/statistics/view/BAU699OD6991> ;
   schema:alternateName "BAU699OD6991" ;
   schema:name "Haushalte in Neubau-Wohnungen nach Bauperiode, Zimmerzahl, Eigentumsart, Haushalttyp und Quartier, seit 2006" ;
   view-builder:source <#source-bew> ;

--- a/apps/api/resources.dev/view/example2.ttl
+++ b/apps/api/resources.dev/view/example2.ttl
@@ -4,8 +4,8 @@ prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix view: <https://cube.link/view/>
 
 <> a </api/View>, view:View ;
-  schema:sameAs <https://ld.stadt-zuerich.ch/statistics/view/679> ;
-  schema:identifier "679" ;
+  schema:isBasedOn <https://ld.stadt-zuerich.ch/statistics/meta/object/679> ;
+  schema:sameAs <https://ld.stadt-zuerich.ch/statistics/view/BAU698OD6981> ;
   schema:alternateName "BAU698OD6981" ;
   schema:name "Wohnungsbestand und Personenzahl in Gebäuden nach Statistischer Zone seit 2008" ;
   view-builder:source <#source-bew>, <#source-stf> ;

--- a/apps/api/resources.dev/view/example3.ttl
+++ b/apps/api/resources.dev/view/example3.ttl
@@ -5,8 +5,8 @@ prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix view: <https://cube.link/view/>
 
 <> a </api/View>, view:View ;
-  schema:sameAs <https://ld.stadt-zuerich.ch/statistics/view/660> ;
-  schema:identifier "660" ;
+  schema:isBasedOn <https://ld.stadt-zuerich.ch/statistics/meta/object/660> ;
+  schema:sameAs <https://ld.stadt-zuerich.ch/statistics/view/BEV525OD5251> ;
   schema:alternateName "BEV525OD5251" ;
   schema:name "Aufenthaltsdauer beim Wegzug nach auswärts nach Alter, Geschlecht, Herkunft und Stadtkreis" ;
   view-builder:source <#source-bew>, <#source-stf> ;

--- a/apps/api/resources/api/View/New.ttl
+++ b/apps/api/resources/api/View/New.ttl
@@ -10,7 +10,7 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
   sh:property
     [
       sh:name "Base View" ;
-      sh:path schema:sameAs ;
+      sh:path schema:isBasedOn ;
       sh:minCount 1 ;
       sh:maxCount 1 ;
       dash:editor dash:InstancesSelectEditor ;

--- a/apps/api/resources/api/View/index.ttl
+++ b/apps/api/resources/api/View/index.ttl
@@ -40,11 +40,18 @@ PREFIX query: <https://hypermedia.app/query#>
     ] ;
   sh:property
     [
-      sh:path schema:identifier ;
+      sh:path schema:alternateName ;
       sh:minCount 1 ;
       sh:maxCount 1 ;
       sh:minLength 1 ;
       sh:datatype xsd:string ;
+    ] ;
+  sh:property
+    [
+      sh:path schema:sameAs ;
+      sh:minCount 1 ;
+      sh:maxCount 1 ;
+      sh:nodeKind sh:IRI ;
     ] ;
   sh:property
     [

--- a/apps/api/resources/api/ViewCollection.ttl
+++ b/apps/api/resources/api/ViewCollection.ttl
@@ -46,7 +46,7 @@ prefix view-builder: <https://view-builder.described.at/>
       hydra:mapping
         [
           hydra:variable "id" ;
-          hydra:property schema:identifier ;
+          hydra:property schema:alternateName ;
           hydra:required true ;
         ] ;
     ] ;

--- a/apps/api/resources/api/config.ttl
+++ b/apps/api/resources/api/config.ttl
@@ -1,3 +1,5 @@
+PREFIX view-builder: <https://view-builder.described.at/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX hydra: <http://www.w3.org/ns/hydra/core#>
 PREFIX code: <https://code.described.at/>
 PREFIX schema: <http://schema.org/>
@@ -5,6 +7,19 @@ PREFIX knossos: <https://hypermedia.app/knossos#>
 
 <>
   a knossos:Configuration ;
+  # TODO: make these env specific
+  view-builder:publisher <https://ld.stadt-zuerich.ch/statistics/meta/org/4> ;
+  view-builder:publishedViewTemplate
+    [
+      a hydra:IriTemplate ;
+      hydra:template "https://ld.stadt-zuerich.ch/statistics/view/{id}" ;
+      hydra:mapping
+        [
+          hydra:variable "id" ;
+          hydra:property schema:alternateName ;
+          hydra:required true ;
+        ] ;
+    ] ;
   knossos:middleware
     [
       schema:name "operations" ;

--- a/apps/www/src/shapes/view.turtle
+++ b/apps/www/src/shapes/view.turtle
@@ -87,17 +87,6 @@ view:In rdfs:label "one of" .
     sh:defaultValue false ;
 .
 
-:PrimaryProperty
-    sh:group :Group_Meta ;
-    sh:name "Internal ID" ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:minLength 1 ;
-    dash:readOnly true ;
-    dash:hidden true ;
-    sh:path schema:identifier ;
-.
-
 :CubeSourceProperty
     sh:path :source ;
     sh:class view:CubeSource ;

--- a/apps/www/src/view/viewCollection.js
+++ b/apps/www/src/view/viewCollection.js
@@ -41,8 +41,8 @@ function table({ state, dispatch }) {
     ?.out(hydra.member)
     .toArray()
     .sort((l, r) => {
-      const leftId = l.out(schema.identifier).value || ''
-      const rightId = r.out(schema.identifier).value || ''
+      const leftId = l.out(schema.alternateName).value || ''
+      const rightId = r.out(schema.alternateName).value || ''
 
       return leftId.localeCompare(rightId)
     }) || []

--- a/packages/publish-views/lib/loadViews.js
+++ b/packages/publish-views/lib/loadViews.js
@@ -58,8 +58,9 @@ function viewIdTransform(from, to) {
     const subject = rename(quad.subject)
     const predicate = rename(quad.predicate)
     const object = rename(quad.object)
+    const graph = rename(object)
 
-    this.push($rdf.quad(subject, predicate, object))
+    this.push($rdf.quad(subject, predicate, object, graph))
     next()
   }
 }

--- a/packages/publish-views/lib/loadViews.js
+++ b/packages/publish-views/lib/loadViews.js
@@ -14,21 +14,24 @@ export default async function loadViewsToPublish() {
     endpointUrl: this.variables.get('METADATA_ENDPOINT'),
   })
 
-  const views = await SELECT`?viewBuilderView ?publishedView`
+  const views = await SELECT`?viewBuilderView ?publishedView ?metaObject`
     .WHERE`
       ?viewBuilderView 
         a ${ns.view.View} ;
         ${schema.sameAs} ?publishedView ; 
+        ${schema.isBasedOn} ?metaObject ;
         ${ns.viewBuilder.publish} true ;
     `
     .execute(client.query)
 
-  return views.pipe(through2.obj(async function ({ viewBuilderView, publishedView }, _, next) {
+  return views.pipe(through2.obj(async function (bindings, _, next) {
+    const { viewBuilderView, publishedView, metaObject } = bindings
+
     const viewQuads = await CONSTRUCT`?s ?p ?o`
       .FROM(viewBuilderView)
       .WHERE`?s ?p ?o`
       .execute(client.query)
-    const metaQuads = await loadViewMeta(publishedView, metaClient)
+    const metaQuads = await loadViewMeta(publishedView, metaObject, metaClient)
 
     const dataset = $rdf.dataset()
     await Promise.all([dataset.import(viewQuads), dataset.import(metaQuads)])
@@ -38,13 +41,27 @@ export default async function loadViewsToPublish() {
   }))
 }
 
-async function loadViewMeta(view, client) {
+async function loadViewMeta(publishedView, metaObject, client) {
   const shape = await viewShape()
 
   const subjectVariable = 'view'
-  const query = shapeTo.construct(shape, { focusNode: view, subjectVariable })
+  const query = shapeTo.construct(shape, { focusNode: metaObject, subjectVariable })
+  const metaStream = await query.execute(client.query)
 
-  return query.execute(client.query)
+  return metaStream.pipe(through2.obj(viewIdTransform(metaObject, publishedView)))
+}
+
+function viewIdTransform(from, to) {
+  const rename = term => (term.equals(from) ? to : from)
+
+  return function renameToPublishedView(quad, cb, next) {
+    const subject = rename(quad.subject)
+    const predicate = rename(quad.predicate)
+    const object = rename(quad.object)
+
+    this.push($rdf.quad(subject, predicate, object))
+    next()
+  }
 }
 
 function createClient(variables) {

--- a/packages/publish-views/shapes.ttl
+++ b/packages/publish-views/shapes.ttl
@@ -21,12 +21,6 @@ prefix view: <https://cube.link/view/>
       sh:nodeKind sh:Literal ;
     ],
     [
-      sh:path schema:identifier ;
-      sh:minCount 1 ;
-      sh:maxCount 1 ;
-      sh:nodeKind sh:Literal ;
-    ],
-    [
       sh:path dcterms:issued ;
       sh:maxCount 1 ;
       sh:or

--- a/packages/publish-views/test/index.test.js
+++ b/packages/publish-views/test/index.test.js
@@ -26,6 +26,7 @@ describe('@view-builder/publish-views', () => {
         const ptr = await testData`
           <>
             a ${view.View}, ${schema.Dataset} ;
+            ${schema.isBasedOn} <https://example.com/view/meta> ;
             ${schema.sameAs} <https://example.com/published/view> ;
             ${view.dimension} [
               ${view.from} [
@@ -40,7 +41,7 @@ describe('@view-builder/publish-views', () => {
           <https://example.com/published/view>
             a ${dcat.Dataset}, ${_void.Dataset} ;
             ${schema.name} "Test view" ;
-            ${schema.identifier} "TEST" ;
+            ${schema.alternateName} "TEST" ;
           .
         `
 
@@ -59,6 +60,7 @@ describe('@view-builder/publish-views', () => {
         const ptr = await testData`
           <>
             a ${view.View}, ${schema.Dataset} ;
+            ${schema.isBasedOn} <https://example.com/view/meta> ;
             ${schema.sameAs} <https://example.com/published/view> ; 
           .`
 
@@ -66,7 +68,7 @@ describe('@view-builder/publish-views', () => {
         const { run } = await runPipeline(ptr)
 
         // then
-        await expect(run.finished).to.be.rejectedWith(ValidationError, '1 views failed. 3 issues found')
+        await expect(run.finished).to.be.rejectedWith(ValidationError, '1 views failed. 2 issues found')
       })
     })
   })

--- a/packages/publish-views/test/shapes.ttl
+++ b/packages/publish-views/test/shapes.ttl
@@ -38,6 +38,14 @@
       sh:maxCount 0 ;
     ] ,
     [
+      sh:path schema:isBasedOn ;
+      sh:maxCount 0 ;
+    ] ,
+    [
+      sh:path schema:identifier ;
+      sh:maxCount 0 ;
+    ] ,
+    [
       sh:path [ sh:inversePath schema:dataset ] ;
       sh:minCount 1 ;
       sh:hasValue <https://ld.stadt-zuerich.ch/catalog/SSZ/view> ;

--- a/packages/view-util/index.js
+++ b/packages/view-util/index.js
@@ -15,7 +15,7 @@ export function prepareViewPointer(pointer, { cleanup = true, removeLimitOffset,
   let view = clownface({ dataset }).node(pointer)
   if (rename) {
     view = rebase(view)
-    view.deleteOut(schema.sameAs)
+    view.deleteOut(schema.sameAs).deleteOut(schema.isBasedOn)
   }
 
   const filters = view.out(ns.view.filter).toArray()

--- a/test/api/view/good/empty.ttl
+++ b/test/api/view/good/empty.ttl
@@ -2,5 +2,5 @@ PREFIX schema: <http://schema.org/>
 
 <>
   a </api/View> ;
-  schema:identifier "empty view" ;
+  schema:alternateName "empty view" ;
 .

--- a/test/api/view/good/single-dimension.ttl
+++ b/test/api/view/good/single-dimension.ttl
@@ -3,7 +3,7 @@ PREFIX view: <https://cube.link/view/>
 
 <>
   a </api/View> ;
-  schema:identifier "single dimension" ;
+  schema:alternateName "single dimension" ;
   view:dimension
     [
       a view:Dimension ;


### PR DESCRIPTION
This PR slightly changes how the views in view builder relate to those defined by the metadata

1. `schema:identifier` is no longer used at all
2. the unique `schema:alternameName` is used to create URIs for published view. No longer is the identifier of the metadata being reused