### PR TITLE
fix: have default source, opened when creating new view

### DIFF
--- a/.changeset/blue-bananas-chew.md
+++ b/.changeset/blue-bananas-chew.md
@@ -1,0 +1,5 @@
+---
+"@view-builder/ui": patch
+---
+
+Automatically create and open the first view Source (re StatistikStadtZuerich/APD#144)

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "@captaincodeman/rdx": "^1.0.0-rc.9",
     "@graphy/content.ttl.read": "^4.3.4",
-    "@hydrofoil/shaperone-core": "^0.10.0",
+    "@hydrofoil/shaperone-core": "^0.10.3",
     "@hydrofoil/shaperone-hydra": "^0.3.15",
-    "@hydrofoil/shaperone-wc": "^0.7.11",
+    "@hydrofoil/shaperone-wc": "^0.7.12",
     "@hydrofoil/shaperone-wc-shoelace": "^0.2.1",
     "@hydrofoil/shell": "^0.3.3",
     "@hydrofoil/vocabularies": "^0.3.2",

--- a/apps/www/src/forms/plugins.js
+++ b/apps/www/src/forms/plugins.js
@@ -1,0 +1,6 @@
+import { addPlugin } from '@hydrofoil/shaperone-core/store.js'
+import { autoExpand } from './plugins/autoExpand.js'
+
+addPlugin({
+  autoExpand,
+})

--- a/apps/www/src/forms/plugins/autoExpand.js
+++ b/apps/www/src/forms/plugins/autoExpand.js
@@ -1,0 +1,23 @@
+import { viewBuilder } from '@view-builder/core/ns.js'
+
+export const autoExpand = {
+  model: {
+    effects(store) {
+      const dispatch = store.getDispatch()
+
+      return {
+        /**
+         * When a property is initialized with `view-builder:source` property,
+         * set it to open
+         */
+        'forms/initObjectValue': (arg) => {
+          const { path } = arg.property
+
+          if ('id' in path && path.id.equals(viewBuilder.source)) {
+            dispatch.forms.updateComponentState({ ...arg, newState: { open: true } })
+          }
+        },
+      }
+    },
+  },
+}

--- a/apps/www/src/index.js
+++ b/apps/www/src/index.js
@@ -1,4 +1,5 @@
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js'
 import './element/ssz-view-builder.js'
+import './forms/plugins.js'
 
 setBasePath('https://unpkg.com/@shoelace-style/shoelace/dist')

--- a/apps/www/src/shapes/view.turtle
+++ b/apps/www/src/shapes/view.turtle
@@ -89,6 +89,7 @@ view:In rdfs:label "one of" .
 
 :CubeSourceProperty
     sh:path :source ;
+    sh:minCount 1 ;
     sh:class view:CubeSource ;
     sh:node :CubeSourceShape ;
     sh:order 10 ;

--- a/apps/www/src/view/viewCollection.js
+++ b/apps/www/src/view/viewCollection.js
@@ -2,13 +2,12 @@ import { html } from 'lit'
 import { hydra, schema } from '@tpluscode/rdf-ns-builders'
 import '@shoelace-style/shoelace/dist/components/button/button.js'
 import '../element/ssz-view-table.js'
+import '../forms/index.js'
 import { viewBuilder } from '@view-builder/core/ns.js'
 import { fromRdf } from 'rdf-literal'
 import { searchForm } from './searchForm.js'
 
 export async function init() {
-  await import('../forms/index.js')
-
   return {
     content,
     menu,
@@ -60,8 +59,6 @@ function table({ state, dispatch }) {
 }
 
 function publishForm({ state, dispatch }) {
-  import('../forms/index.js')
-
   const { shape, operation } = state.viewPublishing
   if (!shape) {
     return html`<sl-spinner></sl-spinner>`
@@ -91,7 +88,7 @@ function publishForm({ state, dispatch }) {
 }
 
 function newViewForm({ state, dispatch }) {
-  import('../forms/index.js')
+  import('@hydrofoil/shaperone-wc/shaperone-form.js')
 
   const { newViewShape, newViewOperation } = state.viewCollection
   if (!newViewShape || newViewShape instanceof Promise) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1481,10 +1481,10 @@
     "@tpluscode/rdf-string" "^0.2.26"
     "@tpluscode/sparql-builder" "^0.3"
 
-"@hydrofoil/shaperone-core@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@hydrofoil/shaperone-core/-/shaperone-core-0.10.0.tgz#a45dbc7fc406a0836acc134af977037c60ec2cb9"
-  integrity sha512-2MKR+s2wxWEeWG3AbI0VilNpYA3TEVr7L4He4g+2smUeWWNTYRnUE78f4IWKuEqoo+uvgieMOzsy3yR0Dys8+Q==
+"@hydrofoil/shaperone-core@^0.10.0", "@hydrofoil/shaperone-core@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@hydrofoil/shaperone-core/-/shaperone-core-0.10.3.tgz#27cbc437081f4d9d6bf563543715fa47f12a0497"
+  integrity sha512-i3HN7p4Bw87Q2Q9XMAiaByksyKa6fGNnlLrys8qLPhFJ73apyP9H6oLT9I8mM3CQuJxSXxhyuFhzm4nAhDW38w==
   dependencies:
     "@captaincodeman/rdx" "^1.0.0-rc.8"
     "@rdf-esm/data-model" "^0.5.3"
@@ -1536,13 +1536,13 @@
     lit "^2"
     p-debounce "^4"
 
-"@hydrofoil/shaperone-wc@^0.7.11":
-  version "0.7.11"
-  resolved "https://registry.yarnpkg.com/@hydrofoil/shaperone-wc/-/shaperone-wc-0.7.11.tgz#530ecdc779bcc90c1c25b53e5b6bfd46b7d42fa8"
-  integrity sha512-LwSkXQGhRNUn/26SiomBeQdY1ivpYODsha6WPefwGzwU+Ap3qcCmE2A/am/JUSat4ZT/2XVYuywRUbzbPFHLzg==
+"@hydrofoil/shaperone-wc@^0.7.11", "@hydrofoil/shaperone-wc@^0.7.12":
+  version "0.7.12"
+  resolved "https://registry.yarnpkg.com/@hydrofoil/shaperone-wc/-/shaperone-wc-0.7.12.tgz#e31edcae1193a69de5c528dab0d483501aca8acb"
+  integrity sha512-1DHgXE5pZ8uSZSKOy6IQliJXRfN113mu/WqrCnV6pNjiU4aeFG4ARK0hVWFEsFvYWVmnwDnqSJ2SJ0LMbmvZFw==
   dependencies:
     "@captaincodeman/rdx" "^1.0.0-rc.8"
-    "@hydrofoil/shaperone-core" "^0.10.0"
+    "@hydrofoil/shaperone-core" "^0.10.3"
     "@rdf-esm/data-model" "^0.5.4"
     "@rdf-esm/dataset" "^0.5.1"
     "@rdf-esm/term-map" "^0.5.0"
@@ -3611,15 +3611,15 @@
   dependencies:
     whatwg-url "^5.0.0"
 
-"@zazuko/rdf-vocabularies@*", "@zazuko/rdf-vocabularies@latest":
-  version "2022.6.29"
-  resolved "https://registry.yarnpkg.com/@zazuko/rdf-vocabularies/-/rdf-vocabularies-2022.6.29.tgz#f81be16f5df6545c87ba0480be30a1ef65f4217c"
-  integrity sha512-E1IyTK3WfeeB0LAPxtDapcBPB+uizhYFGBgjK0z9xMnGIeWWtWb59jpGxLTfVjHMbGbxeTm/HPAKLwtB1gX1xQ==
+"@zazuko/rdf-vocabularies@*", "@zazuko/rdf-vocabularies@^2022.6.29", "@zazuko/rdf-vocabularies@latest":
+  version "2022.11.28"
+  resolved "https://registry.yarnpkg.com/@zazuko/rdf-vocabularies/-/rdf-vocabularies-2022.11.28.tgz#fa2adc7cffffac4673339805c871b7b1f6f8cadf"
+  integrity sha512-fg3GwDMI2ooS6VA2C23hFy5BrY5WO4lwjwa0/jYLYUpEHorTk430X0MvKQcfEgyz6U4NO8QDS8jz1CGvC4YLAw==
   dependencies:
     "@rdfjs/parser-n3" "^1.1.4"
     commander "^5.0.0"
     pkg-dir "^5.0.0"
-    rdf-ext "^1.3.1"
+    rdf-ext "^1.3.5"
     readable-stream "^3.6.0"
     string-to-stream "^3.0.1"
 


### PR DESCRIPTION
Now, a new view will have a blank source the way it used to in the beginning and that view will be automatically expanded
Existing views however, will not

The biggest difference is that because of `sh:minCount`, the last source will not be possible to remove

[https_view-builder.lndo.siteappviews (1).webm](https://user-images.githubusercontent.com/588128/204861922-6ba8ee28-392a-4869-bcdc-af822964132d.webm)
