### PR TITLE
Validate dimension without schema:identifier

### DIFF
--- a/.changeset/metal-lamps-explain.md
+++ b/.changeset/metal-lamps-explain.md
@@ -1,0 +1,5 @@
+---
+"@view-builder/publish-views": patch
+---
+
+Add warning when dimension would be published without a `schema:identifier`

--- a/.changeset/ninety-feet-retire.md
+++ b/.changeset/ninety-feet-retire.md
@@ -1,0 +1,5 @@
+---
+"@view-builder/publish-views": patch
+---
+
+Do not fail pipeline when dimension identifier cannot be found

--- a/packages/publish-views/shapes.ttl
+++ b/packages/publish-views/shapes.ttl
@@ -96,5 +96,12 @@ prefix ssz: <https://ld.stadt-zuerich.ch/schema/>
     [
       sh:path dcat:keyword ;
       sh:nodeKind sh:Literal ;
+    ],
+    [
+      sh:path (view:dimension schema:identifier) ;
+      sh:minCount 1 ;
+      sh:maxCount 1 ;
+      sh:message "Missing dimension identifier" ;
+      sh:severity sh:Warning ;
     ] ;
 .

--- a/packages/publish-views/shapes.ttl
+++ b/packages/publish-views/shapes.ttl
@@ -92,7 +92,7 @@ prefix ssz: <https://ld.stadt-zuerich.ch/schema/>
     [
       sh:path dcat:theme ;
       sh:nodeKind sh:Literal ;
-    ] ,
+    ],
     [
       sh:path dcat:keyword ;
       sh:nodeKind sh:Literal ;

--- a/packages/publish-views/test/index.test.js
+++ b/packages/publish-views/test/index.test.js
@@ -57,10 +57,9 @@ describe('@view-builder/publish-views', () => {
 
         // when
         const { run } = await runPipeline(ptr)
-        await run.finished
 
         // then
-        expect(run.pipeline.variables.get('error')).to.be.undefined
+        await expect(run.finished).to.be.eventually.fulfilled
       })
 
       it('when dimension has generated lookup dimensions', async () => {
@@ -90,10 +89,9 @@ describe('@view-builder/publish-views', () => {
 
         // when
         const { run } = await runPipeline(ptr)
-        await run.finished
 
         // then
-        expect(run.pipeline.variables.get('error')).to.be.undefined
+        await expect(run.finished).to.be.eventually.fulfilled
       })
 
       it('when linked source cube is not found', async () => {
@@ -144,7 +142,7 @@ describe('@view-builder/publish-views', () => {
         const { run } = await runPipeline(ptr)
 
         // then
-        await expect(run.finished).to.be.rejectedWith(ValidationError, '1 views failed. 2 issues found')
+        await expect(run.finished).to.be.rejectedWith(ValidationError, '1 views failed. 3 issues found')
       })
     })
 
@@ -158,6 +156,7 @@ describe('@view-builder/publish-views', () => {
         variables: {
           views,
           metaLookup,
+          ignoreWarnings: true,
         },
       })
     }

--- a/packages/view-util/lib/dimensions.js
+++ b/packages/view-util/lib/dimensions.js
@@ -15,7 +15,7 @@ export async function populateDimensionIdentifiers(pointer, metaLookup) {
     .out(ns.view.cube)
     .terms
 
-  const cubeKeys = await metaLookup.getCubeKeys(...cubes)
+  const cubesAndKeys = await metaLookup.getCubeKeys(...cubes)
   const dimensionIdentifiers = await metaLookup.getDimensionIdentifiers()
 
   pointer
@@ -43,9 +43,11 @@ export async function populateDimensionIdentifiers(pointer, metaLookup) {
       const { identifier, type } = dimensionIdentifiers.get(property) || {}
 
       if (ns.cube.MeasureDimension.equals(type)) {
-        const { cubeKey } = cubeKeys.find(bindings => cube.equals(bindings.cube))
+        const found = cubesAndKeys.find(bindings => cube.equals(bindings.cube))
 
-        dimension.addOut(schema.identifier, cubeKey)
+        if (found) {
+          dimension.addOut(schema.identifier, found.cubeKey)
+        }
       } else if (ns.cube.KeyDimension.equals(type)) {
         dimension.addOut(schema.identifier, `${identifier}_uri`)
       }


### PR DESCRIPTION
We add `schema:identifier` to all dimensions which is used a exported CSV column

In case when a cube would not be found we are unable to find dimension's identifier but did not handle that gracefully. Now the code will not throw and a SHACL validation warning is generated